### PR TITLE
Use exec for starting mono so that current process is reused

### DIFF
--- a/Grace/grace
+++ b/Grace/grace
@@ -3,4 +3,4 @@
 # Resolve a single layer of symlink and then an absolute path
 # to the directory holding this script, so that we can find the
 # executable relative to it.
-mono --debug "$(cd "$(dirname "$([ -h "$0" ]&&ls -l "$0"|sed -e 's/.*-> //'||printf '%s\n' "$0")")" ; pwd -P)"/bin/Debug/Grace.exe "$@"
+exec mono --debug "$(cd "$(dirname "$([ -h "$0" ]&&ls -l "$0"|sed -e 's/.*-> //'||printf '%s\n' "$0")")" ; pwd -P)"/bin/Debug/Grace.exe "$@"


### PR DESCRIPTION
This avoids using an extra process for mono, which makes it easy to kill kernan forcefully when necessary from the outside, because it avoids trying to determine the process tree.