### PR TITLE
Make public things that are needed for my Grace type-checker

### DIFF
--- a/GraceLanguage/Parsing/Lexer.cs
+++ b/GraceLanguage/Parsing/Lexer.cs
@@ -9,7 +9,7 @@ using Grace.Utility;
 namespace Grace.Parsing
 {
     /// <summary>Tokeniser for Grace code</summary>
-    class Lexer
+    public class Lexer
     {
         private string code;
         private int index = 0;
@@ -444,7 +444,7 @@ namespace Grace.Parsing
             return new CommentToken(moduleName, line, column, body);
         }
 
-        private static bool isOperatorCharacter(char c, UnicodeCategory cat)
+        public static bool isOperatorCharacter(char c, UnicodeCategory cat)
         {
             return c != '"' && c != ',' && c != ';'
                 &&

--- a/GraceLanguage/Runtime/DictionaryDataObject.cs
+++ b/GraceLanguage/Runtime/DictionaryDataObject.cs
@@ -5,7 +5,7 @@ using Grace.Parsing;
 
 namespace Grace.Runtime
 {
-    class DictionaryDataObject : GraceObject,
+    public class DictionaryDataObject : GraceObject,
         IEnumerable<KeyValuePair<string, GraceObject>>
     {
         private Dictionary<string, GraceObject> data;

--- a/GraceLanguage/Utility/UnicodeLookup.cs
+++ b/GraceLanguage/Utility/UnicodeLookup.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 
 namespace Grace.Utility
 {
-    static class UnicodeLookup
+    public static class UnicodeLookup
     {
         /// <summary>Get the UnicodeData.txt elements for a
         /// particular codepoint</summary>


### PR DESCRIPTION
I have added a few public modifiers to some classes.
This is the minimal set of changes I need for my grace type-checker.
See <https://gitlab.ecs.vuw.ac.nz/isaac/GraceTC/tree/vanilla-kernan>, specifically the following files:
* [`kernan-module/kernan-parser.csproj`](https://gitlab.ecs.vuw.ac.nz/isaac/GraceTC/blob/vanilla-kernan/kernan-module/kernan-parser.csproj) this is the hand-edit project file for my kernan module, which ensures the module is correctly linked with kernan and places the compiled dll in the appropriate place for kernan to find it.
* [`kernan-module/KernanParser.cs`](https://gitlab.ecs.vuw.ac.nz/isaac/GraceTC/blob/vanilla-kernan/kernan-module/KernanParser.cs) this is the source code for my module which relies on the changes in this pull request. It exposes a few methods to grace that I need for my type-checker.
* [`kernan-module/Callback.cs`](https://gitlab.ecs.vuw.ac.nz/isaac/GraceTC/blob/vanilla-kernan/kernan-module/Callback.cs) this provides a very simple and easy to use library for making Grace callbacks in C# code, it is a drasticly simpler version of kernans own `Methods.cs` file (which defines class like `DelagateMethod1Ctx`), I would suggest changed `Methods.cs` to something like my `Callback.cs` file as it will allow lots of reduction of code bloat, and allow for more easily exposing methods to grace.
* [`build-kernan.sh`](https://gitlab.ecs.vuw.ac.nz/isaac/GraceTC/blob/vanilla-kernan/build-kernan.sh)
This is a script that will download and compile my modified kernan version and build my kernan module.