### PR TITLE
Simplified kernancompiler module and added extra features

### DIFF
--- a/GraceLanguage/Execution/Interpreter.cs
+++ b/GraceLanguage/Execution/Interpreter.cs
@@ -702,7 +702,7 @@ namespace Grace.Execution
         /// <inheritdoc />
         public int NestRequest(string module, int line, string name)
         {
-            if (callStackMethod.Count > 511) {
+            if (callStackMethod.Count > 1023) {
                 ErrorReporting.RaiseError(this, "R2024",
                         new Dictionary<string, string>(),
                         "RecursionError: maximum call stack size exceeded."

--- a/GraceLanguage/Execution/Interpreter.cs
+++ b/GraceLanguage/Execution/Interpreter.cs
@@ -366,9 +366,11 @@ namespace Grace.Execution
                         continue;
                     }
                     filePath = Path.Combine(p, path + ".grace");
-                    mod = tryLoadModuleFile(filePath, path);
-                    if (mod != null)
+
+                    String mod_contents = TryReadModuleFile(filePath, path);
+                    if (mod_contents != null)
                     {
+                        mod = LoadModuleString(filePath, mod_contents);
                         modules[path] = mod;
                         return mod;
                     }
@@ -402,12 +404,14 @@ namespace Grace.Execution
             return null;
         }
 
-        /// <summary>Load a module file if it exists</summary>
-        private GraceObject tryLoadModuleFile(string filePath,
+        /// <summary>Read a module file if it exists</summary>
+        /// <param name="filePath">Filesystem path to the module</param>
+        /// <param name="importPath"> Module name to treat this code as belonging to. </param>
+        public String TryReadModuleFile(string filePath,
                 string importPath)
         {
             return (File.Exists(filePath))
-                ? loadModuleFile(filePath, importPath)
+                ? readModuleFile(filePath, importPath)
                 : null;
         }
 
@@ -429,13 +433,13 @@ namespace Grace.Execution
                 : null;
         }
 
-        /// <summary>Load a module file</summary>
-        private GraceObject loadModuleFile(string filePath, string importPath)
+        /// <summary>Read a module file</summary>
+        private String readModuleFile(string filePath, string importPath)
         {
             Interpreter.Debug("========== LOAD " + filePath + " ==========");
             using (StreamReader reader = File.OpenText(filePath))
             {
-                return LoadModuleString(importPath, reader.ReadToEnd());
+                return reader.ReadToEnd();
             }
         }
 

--- a/GraceLanguage/Execution/Interpreter.cs
+++ b/GraceLanguage/Execution/Interpreter.cs
@@ -257,6 +257,34 @@ namespace Grace.Execution
                 ext.Request(this, req);
                 GraceString.ExtendWith(req.InheritedMethods);
             }
+            req = MethodRequest.Nullary("BooleanExtension");
+            req.IsInherits = true;
+            if (ext.RespondsTo(req))
+            {
+                var uo = new UserObject();
+                req.InheritingObject = uo;
+                ext.Request(this, req);
+                GraceBoolean.ExtendWith(req.InheritedMethods);
+            }
+            req = MethodRequest.Nullary("SequenceExtension");
+            req.IsInherits = true;
+            if (ext.RespondsTo(req))
+            {
+                var uo = new UserObject();
+                req.InheritingObject = uo;
+                ext.Request(this, req);
+                Iterables.ExtendWith(req.InheritedMethods);
+            }
+            req = MethodRequest.Nullary("TypeExtension");
+            req.IsInherits = true;
+            if (ext.RespondsTo(req))
+            {
+                var uo = new UserObject();
+                req.InheritingObject = uo;
+                ext.Request(this, req);
+                GraceType.ExtendWith(req.InheritedMethods);
+            }
+
         }
 
         /// <summary>

--- a/GraceLanguage/Parsing/ParseNodes.cs
+++ b/GraceLanguage/Parsing/ParseNodes.cs
@@ -1953,15 +1953,15 @@ namespace Grace.Parsing
     /// </summary>
     public static class ParseNodeMeta
     {
-        private static Dictionary<string, GraceObject> parseNodes;
+        private static DictionaryDataObject parseNodes;
 
         /// <summary>
         /// Get dictionary of parse node names to patterns.
         /// </summary>
-        public static Dictionary<string, GraceObject> GetPatternDict()
+        public static GraceObject GetPatternDict()
         {
             if (parseNodes == null)
-                parseNodes = new Dictionary<string, GraceObject> {
+                parseNodes = new DictionaryDataObject(new Dictionary<string, GraceObject> {
                     { "Object", new NativeTypePattern<ObjectParseNode>() },
                     { "MethodDeclaration",
                         new NativeTypePattern<MethodDeclarationParseNode>() },
@@ -2021,7 +2021,7 @@ namespace Grace.Parsing
                         new NativeTypePattern<ParenthesisedParseNode>() },
                     { "Comment", new NativeTypePattern<CommentParseNode>() },
 
-                };
+                });
             return parseNodes;
         }
 
@@ -2033,8 +2033,7 @@ namespace Grace.Parsing
             string path = Path.Combine(dir, "pretty_printer.grace");
             GraceObject ret;
             LocalScope surrounding = new LocalScope();
-            surrounding.AddLocalDef("parseNodes",
-                    new DictionaryDataObject(GetPatternDict()));
+            surrounding.AddLocalDef("parseNodes", GetPatternDict());
             ctx.Extend(surrounding);
             using (StreamReader reader = File.OpenText(path))
             {

--- a/GraceLanguage/Runtime/GraceObject.cs
+++ b/GraceLanguage/Runtime/GraceObject.cs
@@ -163,6 +163,7 @@ namespace Grace.Runtime
                 AddMethod("asString", null);
                 AddMethod("==(_)", null);
                 AddMethod("!=(_)", null);
+                AddMethod("hash", null);
             }
         }
 
@@ -216,6 +217,15 @@ namespace Grace.Runtime
                 GraceObject other)
         {
             return GraceBoolean.Create(!object.ReferenceEquals(self, other));
+        }
+
+        /// <summary>Native method supporting Grace hash</summary>
+        /// <param name="ctx">Current interpreter</param>
+        /// <param name="self">Receiver</param>
+        private static GraceObject mHash(EvaluationContext ctx,
+                GraceObject self)
+        {
+            return GraceNumber.Create(RuntimeHelpers.GetHashCode(self));
         }
 
         /// <summary>Remove a method from this object</summary>
@@ -288,6 +298,9 @@ namespace Grace.Runtime
                     return m;
                 case "!=(_)":
                     m = new DelegateMethodReceiver1Ctx(mNotEquals);
+                    return m;
+                case "hash":
+                    m = new DelegateMethodReceiver0Ctx(mHash);
                     return m;
             }
             return null;

--- a/GraceLanguage/Runtime/GraceObjectProxy.cs
+++ b/GraceLanguage/Runtime/GraceObjectProxy.cs
@@ -114,7 +114,12 @@ namespace Grace.Runtime
                         },
                         "LookupError: Native proxy failed to find method «${method}»"
                 );
-            return GraceObjectProxy.Create(meth.Invoke(obj, args));
+            try {
+                return GraceObjectProxy.Create(meth.Invoke(obj, args));
+            } catch (TargetInvocationException ex) {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw null; // Unreachable
+            }
         }
 
         private static object viewAsNative(Object obj)

--- a/GraceLanguage/Runtime/Iterables.cs
+++ b/GraceLanguage/Runtime/Iterables.cs
@@ -11,7 +11,7 @@ namespace Grace.Runtime
     /// <summary>Encapsulates behaviour relating to iterables</summary>
     public static class Iterables
     {
-        internal static Dictionary<string, Method> sharedMethods;
+        internal static Dictionary<string, Method> sharedMethods = new Dictionary<string, Method> { };
 
         /// <summary>
         /// Apply an extension trait to all future instances of this type.
@@ -21,8 +21,6 @@ namespace Grace.Runtime
         /// </param>
         public static void ExtendWith(IDictionary<string, Method> meths)
         {
-            if (sharedMethods == null)
-                sharedMethods = new Dictionary<string, Method> { };
             foreach (var m in meths)
                 sharedMethods[m.Key] = m.Value;
         }

--- a/GraceLanguage/Runtime/Iterables.cs
+++ b/GraceLanguage/Runtime/Iterables.cs
@@ -11,6 +11,22 @@ namespace Grace.Runtime
     /// <summary>Encapsulates behaviour relating to iterables</summary>
     public static class Iterables
     {
+        internal static Dictionary<string, Method> sharedMethods;
+
+        /// <summary>
+        /// Apply an extension trait to all future instances of this type.
+        /// </summary>
+        /// <param name="meths">
+        /// Dictionary of methods to add.
+        /// </param>
+        public static void ExtendWith(IDictionary<string, Method> meths)
+        {
+            if (sharedMethods == null)
+                sharedMethods = new Dictionary<string, Method> { };
+            foreach (var m in meths)
+                sharedMethods[m.Key] = m.Value;
+        }
+
         /// <summary>
         /// Execute a block of native code for each element
         /// of an iterable.
@@ -56,6 +72,7 @@ namespace Grace.Runtime
                     new DelegateMethod1Ctx(
                         new NativeMethod1Ctx(this.Do)));
                 AddMethod("++(_)", Iterables.ConcatMethod);
+                AddMethods(sharedMethods);
                 TagName = "ConcatenatedIterables";
             }
 
@@ -112,6 +129,7 @@ namespace Grace.Runtime
             AddMethod("with(_) do(_)",
                 new DelegateMethodReq(
                     new NativeMethodReq(this.WithDo)));
+            AddMethods(Iterables.sharedMethods);
             TagName = "Lineup";
         }
 

--- a/GraceLanguage/Runtime/Matching.cs
+++ b/GraceLanguage/Runtime/Matching.cs
@@ -103,7 +103,7 @@ namespace Grace.Runtime
                 GraceObject self, GraceObject other)
         {
             var patReq = new MethodRequest();
-            patReq.AddPart(new RequestPart("_OrPattern",
+            patReq.AddPart(new RequestPart("_AndPattern",
                         RequestPart.EmptyList,
                         new List<GraceObject> { self, other }));
             GraceObject patRec = ctx.FindReceiver(patReq);

--- a/GraceLanguage/Runtime/Matching.cs
+++ b/GraceLanguage/Runtime/Matching.cs
@@ -127,6 +127,7 @@ namespace Grace.Runtime
             AddMethod("match(_)", new DelegateMethod1Ctx(mMatch));
             AddMethod("|(_)", Matching.OrMethod);
             AddMethod("&(_)", Matching.AndMethod);
+            AddMethods(GraceType.sharedMethods);
         }
 
         /// <summary>Native method for Grace match</summary>

--- a/GraceLanguage/modules/platform/kernancompiler.cs
+++ b/GraceLanguage/modules/platform/kernancompiler.cs
@@ -24,7 +24,7 @@ namespace KernanCompiler
         public ExposedCompiler() : base("platform/kernancompiler")
         {
             AddMethod("parse(_)", new DelegateMethod1(code => mParse(GraceString.Create("source code"), code)));
-            AddMethod("parse(_, _)",
+            AddMethod("parse(_,_)",
                 new DelegateMethodReq((ctx, req) => {
                 MethodHelper.CheckArity(ctx, req, 2);
                 return mParse(req[0].Arguments[0], req[0].Arguments[1]); }));

--- a/GraceLanguage/modules/platform/kernancompiler.cs
+++ b/GraceLanguage/modules/platform/kernancompiler.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using Grace.Parsing;
 using Grace.Execution;
@@ -12,7 +14,6 @@ namespace KernanCompiler
     [ModuleEntryPoint]
     public class ExposedCompiler : GraceObject
     {
-        private ParseNodePatternDictObject parseNodes;
 
         public static GraceObject Instantiate(
             EvaluationContext ctx)
@@ -22,41 +23,72 @@ namespace KernanCompiler
 
         public ExposedCompiler() : base("platform/kernancompiler")
         {
-            AddMethod("parse(_)", new DelegateMethod1(
-                        new NativeMethod1(mParse)));
-            AddMethod("parseFile(_)", new DelegateMethod1(
-                        new NativeMethod1(mParseFile)));
-            AddMethod("translateFile(_)", new DelegateMethod1(
-                        new NativeMethod1(mTranslateFile)));
-            AddMethod("parseNodes", new DelegateMethod0(
-                        new NativeMethod0(mParseNodes)));
+            AddMethod("parse(_)", new DelegateMethod1(code => mParse(GraceString.Create("source code"), code)));
+            AddMethod("parse(_, _)",
+                new DelegateMethodReq((ctx, req) => {
+                MethodHelper.CheckArity(ctx, req, 2);
+                return mParse(req[0].Arguments[0], req[0].Arguments[1]); }));
+            AddMethod("parseFile(_)", new DelegateMethod1(mParseFile));
+            AddMethod("readGraceModule(_)", new DelegateMethod1Ctx(mReadGraceModule));
+            AddMethod("translateFile(_)", new DelegateMethod1(mTranslateFile));
+            AddMethod("parseNodes", new DelegateMethod0(() => ParseNodeMeta.GetPatternDict()));
             AddMethod("args", new DelegateMethod0(
-                        new NativeMethod0(mArguments)));
+                () => GraceVariadicList.Of(UnusedArguments.UnusedArgs.Select(GraceString.Create))));
         }
 
-        private GraceObject mParse(GraceObject code)
+        private GraceObject mParse(GraceObject gmodulename, GraceObject gcode)
         {
-            GraceString gs = code.FindNativeParent<GraceString>();
-            string s = gs.Value;
-            var p = new Parser(s);
-            return new GraceObjectProxy(p.Parse());
+            String modulename = gmodulename.FindNativeParent<GraceString>().Value;
+            String code = gcode.FindNativeParent<GraceString>().Value;
+            return new GraceObjectProxy(new Parser(modulename, code));
         }
 
-        private GraceObject mParseFile(GraceObject code)
+        private GraceObject mParseFile(GraceObject gpath)
         {
-            GraceString gs = code.FindNativeParent<GraceString>();
-            string path = gs.Value;
+            String path = gpath.FindNativeParent<GraceString>().Value;
             using (StreamReader reader = File.OpenText(path))
             {
-                var p= new Parser(reader.ReadToEnd());
-                return new GraceObjectProxy(p.Parse());
+                return new GraceObjectProxy(new Parser(path, reader.ReadToEnd()).Parse());
             }
         }
 
-        private GraceObject mTranslateFile(GraceObject code)
+        private GraceObject mReadGraceModule(EvaluationContext ctx, GraceObject gpath)
         {
-            GraceString gs = code.FindNativeParent<GraceString>();
-            string path = gs.Value;
+            var itp = (Interpreter)ctx;
+            String path = gpath.FindNativeParent<GraceString>().Value;
+
+            var name = Path.GetFileName(path);
+            var bases = itp.GetModulePaths();
+            foreach (var p in bases)
+            {
+                string filePath;
+
+                filePath = Path.Combine(p, path + ".grace");
+
+                String mod_contents = itp.TryReadModuleFile(filePath, path);
+                if (mod_contents != null)
+                {
+                    return GraceString.Create(mod_contents.Replace(Environment.NewLine, "\u2028"));
+                }
+            }
+            if (itp.FailedImportHook != null)
+            {
+                // Optionally, the host program can try to satisfy a module
+                // and indicate that we should retry the import.
+                if (itp.FailedImportHook(path, itp))
+                {
+                    return mReadGraceModule(itp, gpath);
+                }
+            }
+            ErrorReporting.RaiseError(itp, "R2005",
+                new Dictionary<string, string> { { "path", path } },
+                "LookupError: Could not find module ${path}");
+            return null;
+        }
+
+        private GraceObject mTranslateFile(GraceObject gpath)
+        {
+            String path = gpath.FindNativeParent<GraceString>().Value;
             using (StreamReader reader = File.OpenText(path))
             {
                 var p = new Parser(reader.ReadToEnd());
@@ -65,74 +97,6 @@ namespace KernanCompiler
                 Node eModule = ett.Translate(module as ObjectParseNode);
                 return eModule;
             }
-        }
-
-        private GraceObject mArguments()
-        {
-            IList<string> unusedArguments = UnusedArguments.UnusedArgs;
-            IList<GraceString> graceUnusedArguments = new List<GraceString>();
-
-            foreach (var a in unusedArguments)
-                graceUnusedArguments.Add(GraceString.Create(a));
-
-            return GraceVariadicList.Of(graceUnusedArguments);
-        }
-
-
-        private GraceObject mParseNodes()
-        {
-            if (parseNodes == null)
-                parseNodes = new ParseNodePatternDictObject();
-            return parseNodes;
-        }
-    }
-
-    class NativeTypePattern<T> : GraceObject {
-        public NativeTypePattern()
-        {
-            AddMethod("match(_)", new DelegateMethod1Ctx(
-                        new NativeMethod1Ctx(mMatch)));
-            AddMethod("|", Matching.OrMethod);
-            AddMethod("&", Matching.AndMethod);
-        }
-
-        /// <summary>Native method for Grace match</summary>
-        /// <param name="ctx">Current interpreter</param>
-        /// <param name="target">Target of the match</param>
-        private GraceObject mMatch(EvaluationContext ctx, GraceObject target)
-        {
-            var gop = target as GraceObjectProxy;
-            if (gop == null)
-                return Matching.FailedMatch(ctx, target);
-            if (gop.Object is T)
-                return Matching.SuccessfulMatch(ctx, target);
-            return Matching.FailedMatch(ctx, target);
-        }
-    }
-
-    class ParseNodePatternDictObject : GraceObject,
-        IEnumerable<KeyValuePair<string, GraceObject>>
-    {
-        private Dictionary<string, GraceObject> data =
-            ParseNodeMeta.GetPatternDict();
-
-        public override GraceObject Request(EvaluationContext ctx,
-                MethodRequest req)
-        {
-            if (data.ContainsKey(req.Name))
-                return data[req.Name];
-            return base.Request(ctx, req);
-        }
-
-        public IEnumerator<KeyValuePair<string, GraceObject>> GetEnumerator()
-        {
-            return data.GetEnumerator();
-        }
-
-        System.Collections.IEnumerator
-            System.Collections.IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
I've made some changes to the `kernancompiler` module and associated kernan features.
Firstly I reduced boilerplate and duplicate code, this required me to change `ParseNodeMeta` to actually provide a `GraceObject` and not a .NET Dictionary.

Secondly I added two extra methods to the `kernancompiler` module:
1. `parse(n, c)`, this is like `parse(c)`, but it tells kernan that the code came from the module called `n`, this will make parse errors more usefull (by telling the user which file has said error).
2. `readGraceModule(m)` this returns the contents of the grace module identifier by `m`, this performs roughly the same logic as kernan internally does for `import "m" as foo`; except that it won't treat resource files and `.dll` files specially. Thus you can say have:
```
foo.dll
foo.grace
```
And `readGraceModule("foo")` will return the contents of the `.grace` file, whereas an `import "foo"` will actually try and load the `.dll` file; the intention is that the `.grace` file will contain meta-data (like method specifications) for the `.dll` file.

In order to not duplicate code, I have modified kernan's import logic slightly to expose a `TryReadModuleFile` method that tries to read a module file, and instead of actually loading it (like the previous `tryLoadModuleFile` method did), it now just returns the contents of the module file as a string.

In order to minimise the number of changes made by this pull request, I have not used my cool [`Callback.cs`](https://gitlab.ecs.vuw.ac.nz/isaac/GraceTC/blob/6d0710efc9eca61ee4adf18a6341346560ad45dc/kernan-module/Callback.cs) library, but I still think it's a good idea.